### PR TITLE
Eapi cleanup

### DIFF
--- a/dev-lisp/cl-closure-template/cl-closure-template-0.2.1.ebuild
+++ b/dev-lisp/cl-closure-template/cl-closure-template-0.2.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit common-lisp-3 elisp-common
 

--- a/x11-wm/stumpwm/stumpwm-1.0.1_rc.ebuild
+++ b/x11-wm/stumpwm/stumpwm-1.0.1_rc.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit common-lisp-3 autotools elisp-common xdg-utils versionator
 


### PR DESCRIPTION
Errors reported for these files with EAPI=6. Bumped to EAPI=7. Note - my other pull request for stumpwm removes the stumpwm-1.0.1_rc.ebuild file.